### PR TITLE
Remove schema ambiguity

### DIFF
--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -54,7 +54,7 @@ if [ ! -e "$FIRST_START_DONE" ]; then
   }
 
   function is_new_schema() {
-    local COUNT=$(ldapsearch -Q -Y EXTERNAL -H ldapi:/// -b cn=schema,cn=config cn | grep -c $1)
+    local COUNT=$(ldapsearch -Q -Y EXTERNAL -H ldapi:/// -b cn=schema,cn=config cn | grep -c "}$1,")
     if [ "$COUNT" -eq 0 ]; then
       echo 1
     else


### PR DESCRIPTION
The former check is ambigious with similiar schema names.
Example:
Installed schema: `core-fd-conf`
New schema: `core-fd`

Previously the schema `core-fd` could not be installed because the schema check was ambigious with `core-fd-conf`.
This problem came up when installing schemas for fusiondirectory